### PR TITLE
Add option multiple seperators

### DIFF
--- a/notify/__init__.py
+++ b/notify/__init__.py
@@ -11,4 +11,4 @@ logging.basicConfig(
 )
 
 name = "notify"
-__version__ = "0.5.0-rc.1"
+__version__ = "0.5.0-rc.2"

--- a/notify/mail.py
+++ b/notify/mail.py
@@ -43,9 +43,9 @@ class NotifyMail:
 
         check_environment_variables(["EMAIL_USER", "MAIL_TENANT_ID", "MAIL_CLIENT_ID", "MAIL_CLIENT_SECRET"])
         self.sender = os.environ.get("EMAIL_USER")
-        self.to = to
-        self.cc = cc
-        self.bcc = bcc
+        self.to = to.replace(";", ",")
+        self.cc = cc.replace(";", ",") if cc is not None else cc
+        self.bcc = bcc.replace(";", ",") if bcc is not None else bcc
         self.subject = subject
         self.message = message
         self.files = [files] if isinstance(files, str) else files

--- a/notify/tests/test_email.py
+++ b/notify/tests/test_email.py
@@ -1,6 +1,7 @@
 import os
 import time
 
+import pytest
 from keyvault import secrets_to_environment
 
 from notify import NotifyMail, format_numbers
@@ -46,10 +47,12 @@ def test_send_email_with_formatted_table():
     time.sleep(2)
 
 
-def test_send_multiple_emails():
+@pytest.mark.parametrize("sep", [",", ";"])
+def test_send_multiple_emails(sep: str):
     message = "This is a test from notify"
+    to = sep.join([os.environ.get("TEST_EMAIL_1"), os.environ.get("TEST_EMAIL_2")])
     response = NotifyMail(
-        to=f"{os.environ.get('TEST_EMAIL_1')}, {os.environ.get('TEST_EMAIL_2')}",
+        to=to,
         subject="Test Notify multiple emails",
         message=message,
     ).send_email()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = zyppnotify
-version = 0.5.0-rc.1
+version = 0.5.0-rc.2
 author = Zypp
 author_email = hello@zypp.io
 description = Send users notifications through various platforms


### PR DESCRIPTION
Now users can also seperate multiple receivers, cc or bcc with `;` instead of only `,`